### PR TITLE
Fixes a crash if you have multiple levels of view controllers

### DIFF
--- a/ECStretchableHeaderView.m
+++ b/ECStretchableHeaderView.m
@@ -374,6 +374,7 @@
 }
 - (void)dealloc
 {
+    [self.attachedScrollView removeObserver:self forKeyPath:@"contentSize"];
     [self.attachedScrollView removeObserver:self forKeyPath:@"contentOffset"];
 }
 


### PR DESCRIPTION
Fixes a crash if you have multiple levels of view controllers with stretchble headers. I got a crash when I used it in a UITextView then popped the view stack. This fixed that problem
