### PR TITLE
Fix import of dependencies for use with frameworks.

### DIFF
--- a/ECStretchableHeaderView.m
+++ b/ECStretchableHeaderView.m
@@ -5,8 +5,8 @@
 //  Created by Eric Castro on 30/07/14.
 //  Copyright (c) 2014 cast.ro. All rights reserved.
 //
-#import <POP.h>
-#import <HTDelegateProxy.h>
+#import <pop/POP.h>
+#import <HTDelegateProxy/HTDelegateProxy.h>
 
 #import "ECStretchableHeaderView.h"
 

--- a/ECStretchableHeaderViewExample/Podfile
+++ b/ECStretchableHeaderViewExample/Podfile
@@ -1,1 +1,2 @@
+use_frameworks!
 pod 'ECStretchableHeaderView'


### PR DESCRIPTION
This change will allow Swift projects to also use the stretchable header view.
